### PR TITLE
fix: handle large transcripts with chunked clipboard paste

### DIFF
--- a/Packages/KoeDomain/Sources/KoeDomain/Errors/TextInsertionError.swift
+++ b/Packages/KoeDomain/Sources/KoeDomain/Errors/TextInsertionError.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum TextInsertionError: KoeError {
     case accessibilityDenied
     case insertionFailed(underlying: Error)
+    case clipboardPasteFailed
 
     public var errorDescription: String? {
         switch self {
@@ -10,6 +11,8 @@ public enum TextInsertionError: KoeError {
             return "Accessibility access denied. Please enable in System Settings."
         case .insertionFailed(let error):
             return "Text insertion failed: \(error.localizedDescription)"
+        case .clipboardPasteFailed:
+            return "Failed to paste text from clipboard. The target application may not support large text input."
         }
     }
 }


### PR DESCRIPTION
## Summary
- Split large text (>2000 chars) into chunks for reliable pasting
- Add proper error checking for clipboard and AppleScript operations
- Scale paste delays based on text size to give target apps time to process
- Add `clipboardPasteFailed` error case for better error messaging

## Test plan
- [ ] Test with small transcript (<50 chars) - should use CGEvents
- [ ] Test with medium transcript (50-2000 chars) - should paste in one chunk
- [ ] Test with large transcript (>2000 chars) - should paste in multiple chunks
- [ ] Verify error sound plays if paste fails

Fixes #15